### PR TITLE
HPHX-20103: Hide language selection dropdown on Hike Viewer

### DIFF
--- a/pages/hikes.js
+++ b/pages/hikes.js
@@ -5,6 +5,7 @@ import ToursList from '../src/components/ToursList';
 import styles from './style.scss';
 import { getMapCategories } from '../src/utils/populate';
 import i18next from '../i18n';
+import { enableLocales } from '../src/config/settings';
 
 const HikePage = () => {
   const [categories, setCategories] = useState([]);
@@ -41,7 +42,7 @@ const HikePage = () => {
 
   return (
     <div className={styles.hikeBody}>
-      <HikeHeader />
+      <HikeHeader enableLocales={enableLocales} />
       <div className={styles.hikeContainer}>
         {categories.map(item => (item.categoryTours !== null ? (
           <ToursList

--- a/src/components/HikeHeader/index.js
+++ b/src/components/HikeHeader/index.js
@@ -13,7 +13,7 @@ import i18next, { locales } from '../../../i18n';
 
 const { Header } = Layout;
 
-const HikeHeader = ({ search, keyword }) => {
+const HikeHeader = ({ search, keyword, enableLocales }) => {
   const { publicRuntimeConfig } = getConfig();
   const router = useRouter();
   const [language, setLanguage] = useState(i18next.language);
@@ -84,15 +84,17 @@ const HikeHeader = ({ search, keyword }) => {
               <HikeSearch keyword={keyword} />
             </div>
           ) : null}
-          <div className={style.switchLang}>
-            <Dropdown overlay={menu} trigger={['click']}>
-              <a className="ant-dropdown-link" onClick={e => e.preventDefault()}>
-                <Icon type="global" />
-                {i18next.t(language)}
-                <Icon type="caret-down" />
-              </a>
-            </Dropdown>
-          </div>
+          {enableLocales ? (
+            <div className={style.switchLang}>
+              <Dropdown overlay={menu} trigger={['click']}>
+                <a className="ant-dropdown-link" onClick={e => e.preventDefault()}>
+                  <Icon type="global" />
+                  {i18next.t(language)}
+                  <Icon type="caret-down" />
+                </a>
+              </Dropdown>
+            </div>
+          ) : null}
         </div>
       </Layout>
     </Row>

--- a/src/config/settings.json
+++ b/src/config/settings.json
@@ -15,5 +15,6 @@
     "key": "",
     "cx": "",
     "url": "https://www.googleapis.com/customsearch/v1"
-    }
+    },
+    "enableLocales": false
 }


### PR DESCRIPTION
## Description
The language selection popup should be hidden for release 9.5.

 Introduced setting named "enableLocales".
       enableLocales = true => Language selection dropdown is shown
                                = false => Language selection dropdown is NOT shown

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
